### PR TITLE
Show last variable (with proper indices, if any) in EOL/EOF failure message

### DIFF
--- a/include/tcframe/io_manipulator/GridIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/GridIOSegmentManipulator.hpp
@@ -17,10 +17,14 @@ namespace tcframe {
 
 class GridIOSegmentManipulator {
 public:
-    static void parse(GridIOSegment* segment, istream* in) {
+    static string parse(GridIOSegment* segment, istream* in) {
         Matrix* variable = segment->variable();
         variable->clear();
         variable->parseFrom(in, *segment->rows(), *segment->columns());
+
+        return TokenFormatter::formatMatrixElement(variable->name(),
+                                                   variable->rows() - 1,
+                                                   variable->columns(variable->rows() - 1) - 1);
     }
 
     static void print(GridIOSegment* segment, ostream* out) {

--- a/include/tcframe/io_manipulator/IOManipulator.hpp
+++ b/include/tcframe/io_manipulator/IOManipulator.hpp
@@ -54,16 +54,17 @@ private:
     }
 
     void parse(const vector<IOSegment*>& segments, istream* in) {
+        string lastVariableName;
         for (IOSegment* segment : segments) {
             if (segment->type() == IOSegmentType::GRID) {
-                GridIOSegmentManipulator::parse((GridIOSegment*) segment, in);
+                lastVariableName = GridIOSegmentManipulator::parse((GridIOSegment*) segment, in);
             } else if (segment->type() == IOSegmentType::LINE) {
-                LineIOSegmentManipulator::parse((LineIOSegment*) segment, in);
+                lastVariableName = LineIOSegmentManipulator::parse((LineIOSegment*) segment, in);
             } else if (segment->type() == IOSegmentType::LINES) {
-                LinesIOSegmentManipulator::parse((LinesIOSegment*) segment, in);
+                lastVariableName = LinesIOSegmentManipulator::parse((LinesIOSegment*) segment, in);
             }
         }
-        WhitespaceManipulator::ensureEof(in);
+        WhitespaceManipulator::ensureEof(in, lastVariableName);
     }
 };
 

--- a/include/tcframe/io_manipulator/IOManipulator.hpp
+++ b/include/tcframe/io_manipulator/IOManipulator.hpp
@@ -64,7 +64,11 @@ private:
                 lastVariableName = LinesIOSegmentManipulator::parse((LinesIOSegment*) segment, in);
             }
         }
-        WhitespaceManipulator::ensureEof(in, lastVariableName);
+        if (!lastVariableName.empty()) {
+            WhitespaceManipulator::ensureEof(in, lastVariableName);
+        } else {
+            WhitespaceManipulator::ensureEof(in);
+        }
     }
 };
 

--- a/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
@@ -17,7 +17,7 @@ namespace tcframe {
 
 class LineIOSegmentManipulator {
 public:
-    static void parse(LineIOSegment* segment, istream* in) {
+    static string parse(LineIOSegment* segment, istream* in) {
         string lastVariableName;
         for (const LineIOSegmentVariable& segmentVariable : segment->variables()) {
             if (!lastVariableName.empty()) {
@@ -36,6 +36,8 @@ public:
             }
         }
         WhitespaceManipulator::parseNewline(in, lastVariableName);
+
+        return lastVariableName;
     }
 
     static void print(LineIOSegment* segment, ostream* out) {

--- a/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
@@ -32,7 +32,8 @@ public:
                 lastVariableName = TokenFormatter::formatVariable(variable->name());
             } else {
                 parseVector((Vector*) variable, size, in);
-                lastVariableName = TokenFormatter::formatVectorElement(variable->name(), size - 1);
+                lastVariableName = TokenFormatter::formatVectorElement(variable->name(),
+                                                                       ((Vector*) variable)->size() - 1);
             }
         }
         WhitespaceManipulator::parseNewline(in, lastVariableName);

--- a/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
@@ -31,9 +31,9 @@ public:
                 parseScalar((Scalar*) variable, in);
                 lastVariableName = TokenFormatter::formatVariable(variable->name());
             } else {
-                parseVector((Vector*) variable, size, in);
-                lastVariableName = TokenFormatter::formatVectorElement(variable->name(),
-                                                                       ((Vector*) variable)->size() - 1);
+                Vector* vectorVariable = (Vector*) variable;
+                parseVector(vectorVariable, size, in);
+                lastVariableName = TokenFormatter::formatVectorElement(variable->name(), vectorVariable->size() - 1);
             }
         }
         WhitespaceManipulator::parseNewline(in, lastVariableName);

--- a/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
@@ -29,11 +29,11 @@ public:
 
             if (variable->type() == VariableType::SCALAR) {
                 parseScalar((Scalar*) variable, in);
+                lastVariableName = TokenFormatter::formatVariable(variable->name());
             } else {
                 parseVector((Vector*) variable, size, in);
+                lastVariableName = TokenFormatter::formatVectorElement(variable->name(), size - 1);
             }
-
-            lastVariableName = TokenFormatter::formatVariable(variable->name());
         }
         WhitespaceManipulator::parseNewline(in, lastVariableName);
     }

--- a/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
@@ -29,23 +29,26 @@ public:
         string lastVariableName;
 
         for (int j = 0; j < *segment->size(); j++) {
-            string lastVariableNameInSegment;
+            bool isFirstColumn = true;
             for (Variable* variable : segment->variables()) {
                 if (variable->type() == VariableType::VECTOR) {
-                    if (!lastVariableNameInSegment.empty()) {
-                        WhitespaceManipulator::parseSpace(in, lastVariableNameInSegment);
+                    if (!isFirstColumn) {
+                        WhitespaceManipulator::parseSpace(in, lastVariableName);
                     }
                     ((Vector*) variable)->parseAndAddElementFrom(in);
+                    lastVariableName = TokenFormatter::formatVectorElement(variable->name(), j);
                 } else {
-                    if (!lastVariableNameInSegment.empty() && !WhitespaceManipulator::canParseNewline(in)) {
-                        WhitespaceManipulator::parseSpace(in, lastVariableNameInSegment);
+                    if (!isFirstColumn && !WhitespaceManipulator::canParseNewline(in)) {
+                        WhitespaceManipulator::parseSpace(in, lastVariableName);
                     }
                     ((Matrix*) variable)->parseAndAddRowFrom(in, j);
+                    lastVariableName = TokenFormatter::formatMatrixElement(variable->name(),
+                                                                           j,
+                                                                           ((Matrix*) variable)->columns(j) - 1);
                 }
-                lastVariableNameInSegment = TokenFormatter::formatVectorElement(variable->name(), j);
+                isFirstColumn = false;
             }
-            WhitespaceManipulator::parseNewline(in, lastVariableNameInSegment);
-            lastVariableName = lastVariableNameInSegment;
+            WhitespaceManipulator::parseNewline(in, lastVariableName);
         }
 
         return lastVariableName;

--- a/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
@@ -17,7 +17,7 @@ namespace tcframe {
 
 class LinesIOSegmentManipulator {
 public:
-    static void parse(LinesIOSegment* segment, istream* in) {
+    static string parse(LinesIOSegment* segment, istream* in) {
         for (Variable* variable : segment->variables()) {
             if (variable->type() == VariableType::VECTOR) {
                 ((Vector*) variable)->clear();
@@ -26,24 +26,29 @@ public:
             }
         }
 
+        string lastVariableName;
+
         for (int j = 0; j < *segment->size(); j++) {
-            string lastVariableName;
+            string lastVariableNameInSegment;
             for (Variable* variable : segment->variables()) {
                 if (variable->type() == VariableType::VECTOR) {
-                    if (!lastVariableName.empty()) {
-                        WhitespaceManipulator::parseSpace(in, lastVariableName);
+                    if (!lastVariableNameInSegment.empty()) {
+                        WhitespaceManipulator::parseSpace(in, lastVariableNameInSegment);
                     }
                     ((Vector*) variable)->parseAndAddElementFrom(in);
                 } else {
-                    if (!lastVariableName.empty() && !WhitespaceManipulator::canParseNewline(in)) {
-                        WhitespaceManipulator::parseSpace(in, lastVariableName);
+                    if (!lastVariableNameInSegment.empty() && !WhitespaceManipulator::canParseNewline(in)) {
+                        WhitespaceManipulator::parseSpace(in, lastVariableNameInSegment);
                     }
                     ((Matrix*) variable)->parseAndAddRowFrom(in, j);
                 }
-                lastVariableName = TokenFormatter::formatVectorElement(variable->name(), j);
+                lastVariableNameInSegment = TokenFormatter::formatVectorElement(variable->name(), j);
             }
-            WhitespaceManipulator::parseNewline(in, lastVariableName);
+            WhitespaceManipulator::parseNewline(in, lastVariableNameInSegment);
+            lastVariableName = lastVariableNameInSegment;
         }
+
+        return lastVariableName;
     }
 
     static void print(LinesIOSegment* segment, ostream* out) {

--- a/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
@@ -41,10 +41,11 @@ public:
                     if (!isFirstColumn && !WhitespaceManipulator::canParseNewline(in)) {
                         WhitespaceManipulator::parseSpace(in, lastVariableName);
                     }
-                    ((Matrix*) variable)->parseAndAddRowFrom(in, j);
+                    Matrix* matrixVariable = (Matrix*) variable;
+                    matrixVariable->parseAndAddRowFrom(in, j);
                     lastVariableName = TokenFormatter::formatMatrixElement(variable->name(),
                                                                            j,
-                                                                           ((Matrix*) variable)->columns(j) - 1);
+                                                                           matrixVariable->columns(j) - 1);
                 }
                 isFirstColumn = false;
             }

--- a/include/tcframe/spec/variable/WhitespaceManipulator.hpp
+++ b/include/tcframe/spec/variable/WhitespaceManipulator.hpp
@@ -46,6 +46,12 @@ public:
         }
     }
 
+    static void ensureEof(istream* in, const string& context) {
+        if (in->peek() != char_traits<char>::eof()) {
+            throw runtime_error("Expected: <EOF> after " + context);
+        }
+    }
+
     static void ensureNoEof(istream* in, const string& context) {
         if (in->peek() == char_traits<char>::eof()) {
             throw runtime_error("Cannot parse for " + context + ". Found: <EOF>");

--- a/test/tcframe/io_manipulator/GridIOSegmentManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/GridIOSegmentManipulatorTests.cpp
@@ -32,6 +32,12 @@ TEST_F(GridIOSegmentManipulatorTests, Parsing_Successful) {
     EXPECT_THAT(M, Eq(vector<vector<int>>{{1, 2, 3}, {4, 5, 6}}));
 }
 
+TEST_F(GridIOSegmentManipulatorTests, Parsing_Successful_CheckLastVariable) {
+    istringstream in("1 2 3\n4 5 6\n");
+
+    EXPECT_THAT(GridIOSegmentManipulator::parse(segment, &in), Eq("'M[1][2]'"));
+}
+
 TEST_F(GridIOSegmentManipulatorTests, Printing_Successful) {
     ostringstream out;
 

--- a/test/tcframe/io_manipulator/IOManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/IOManipulatorTests.cpp
@@ -19,37 +19,82 @@ protected:
     vector<int> V;
     vector<vector<int>> M;
 
-    IOManipulator* manipulator;
+    IOManipulator* manipulatorEndsWithScalar;
+    IOManipulator* manipulatorEndsWithVector;
+    IOManipulator* manipulatorEndsWithGrid;
 
     void SetUp() {
-        IOFormatBuilder ioFormatBuilder;
-        ioFormatBuilder.prepareForInputFormat();
-        ioFormatBuilder.newLineIOSegment()
-                .addScalarVariable(Scalar::create(A, "A"));
-        ioFormatBuilder.newLinesIOSegment()
-                .addVectorVariable(Vector::create(V, "V"))
-                .setSize(new int(2));
-        ioFormatBuilder.newGridIOSegment()
-                .addMatrixVariable(Matrix::create(M, "M"))
-                .setSize(new int(2), new int(2));
-        IOFormat ioFormat = ioFormatBuilder.build();
+        {
+            IOFormatBuilder ioFormatBuilder;
+            ioFormatBuilder.prepareForInputFormat();
+            ioFormatBuilder.newLineIOSegment()
+                    .addScalarVariable(Scalar::create(A, "A"));
+            IOFormat ioFormat = ioFormatBuilder.build();
 
-        manipulator = new IOManipulator(ioFormat);
+            manipulatorEndsWithScalar = new IOManipulator(ioFormat);
+        }
+        {
+            IOFormatBuilder ioFormatBuilder;
+            ioFormatBuilder.prepareForInputFormat();
+            ioFormatBuilder.newLineIOSegment()
+                    .addScalarVariable(Scalar::create(A, "A"));
+            ioFormatBuilder.newLinesIOSegment()
+                    .addVectorVariable(Vector::create(V, "V"))
+                    .setSize(new int(2));
+            IOFormat ioFormat = ioFormatBuilder.build();
+
+            manipulatorEndsWithVector = new IOManipulator(ioFormat);
+        }
+        {
+            IOFormatBuilder ioFormatBuilder;
+            ioFormatBuilder.prepareForInputFormat();
+            ioFormatBuilder.newLineIOSegment()
+                    .addScalarVariable(Scalar::create(A, "A"));
+            ioFormatBuilder.newLinesIOSegment()
+                    .addVectorVariable(Vector::create(V, "V"))
+                    .setSize(new int(2));
+            ioFormatBuilder.newGridIOSegment()
+                    .addMatrixVariable(Matrix::create(M, "M"))
+                    .setSize(new int(2), new int(2));
+            IOFormat ioFormat = ioFormatBuilder.build();
+
+            manipulatorEndsWithGrid = new IOManipulator(ioFormat);
+        }
     }
 };
 
 TEST_F(IOManipulatorTests, Parsing_Successful) {
     istringstream in("123\n42\n7\n5 6\n7 8\n");
-    manipulator->parseInput(&in);
+    manipulatorEndsWithGrid->parseInput(&in);
     EXPECT_THAT(A, Eq(123));
     EXPECT_THAT(V, Eq((vector<int>{42, 7})));
     EXPECT_THAT(M, Eq((vector<vector<int>>{{5, 6}, {7, 8}})));
 }
 
-TEST_F(IOManipulatorTests, Parsing_Failed_MissingEof) {
+TEST_F(IOManipulatorTests, Parsing_EndsWithScalar_Failed_MissingEof) {
     istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
     try {
-        manipulator->parseInput(&in);
+        manipulatorEndsWithScalar->parseInput(&in);
+        FAIL();
+    } catch(runtime_error& e) {
+        EXPECT_THAT(e.what(), StrEq("Expected: <EOF> after 'A'"));
+    }
+}
+
+TEST_F(IOManipulatorTests, Parsing_EndsWithVector_Failed_MissingEof) {
+    istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
+    try {
+        manipulatorEndsWithVector->parseInput(&in);
+        FAIL();
+    } catch(runtime_error& e) {
+        EXPECT_THAT(e.what(), StrEq("Expected: <EOF> after 'V[1]'"));
+    }
+}
+
+TEST_F(IOManipulatorTests, Parsing_EndsWithGrid_Failed_MissingEof) {
+    istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
+    try {
+        manipulatorEndsWithGrid->parseInput(&in);
         FAIL();
     } catch(runtime_error& e) {
         EXPECT_THAT(e.what(), StrEq("Expected: <EOF> after 'M[1][1]'"));
@@ -61,7 +106,7 @@ TEST_F(IOManipulatorTests, Printing_Successful) {
     V = {42, 7};
     M = {{5, 6}, {7, 8}};
     ostringstream out;
-    manipulator->printInput(&out);
+    manipulatorEndsWithGrid->printInput(&out);
     EXPECT_THAT(out.str(), Eq("123\n42\n7\n5 6\n7 8\n"));
 }
 

--- a/test/tcframe/io_manipulator/IOManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/IOManipulatorTests.cpp
@@ -124,7 +124,7 @@ TEST_F(IOManipulatorTests, Printing_Successful) {
     V = {42, 7};
     M = {{5, 6}, {7, 8}};
     ostringstream out;
-        manipulatorWithMatrixLast->printInput(&out);
+    manipulatorWithMatrixLast->printInput(&out);
     EXPECT_THAT(out.str(), Eq("123\n42\n7\n5 6\n7 8\n"));
 }
 

--- a/test/tcframe/io_manipulator/IOManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/IOManipulatorTests.cpp
@@ -19,9 +19,9 @@ protected:
     vector<int> V;
     vector<vector<int>> M;
 
-    IOManipulator* manipulatorEndsWithScalar;
-    IOManipulator* manipulatorEndsWithVector;
-    IOManipulator* manipulatorEndsWithGrid;
+    IOManipulator* manipulatorWithScalarLast;
+    IOManipulator* manipulatorWithVectorLast;
+    IOManipulator* manipulatorWithMatrixLast;
     IOManipulator* manipulatorEmpty;
 
     void SetUp() {
@@ -39,7 +39,7 @@ protected:
                     .addScalarVariable(Scalar::create(A, "A"));
             IOFormat ioFormat = ioFormatBuilder.build();
 
-            manipulatorEndsWithScalar = new IOManipulator(ioFormat);
+            manipulatorWithScalarLast = new IOManipulator(ioFormat);
         }
         {
             IOFormatBuilder ioFormatBuilder;
@@ -51,7 +51,7 @@ protected:
                     .setSize(new int(2));
             IOFormat ioFormat = ioFormatBuilder.build();
 
-            manipulatorEndsWithVector = new IOManipulator(ioFormat);
+            manipulatorWithVectorLast = new IOManipulator(ioFormat);
         }
         {
             IOFormatBuilder ioFormatBuilder;
@@ -66,20 +66,20 @@ protected:
                     .setSize(new int(2), new int(2));
             IOFormat ioFormat = ioFormatBuilder.build();
 
-            manipulatorEndsWithGrid = new IOManipulator(ioFormat);
+            manipulatorWithMatrixLast = new IOManipulator(ioFormat);
         }
     }
 };
 
 TEST_F(IOManipulatorTests, Parsing_Successful) {
     istringstream in("123\n42\n7\n5 6\n7 8\n");
-    manipulatorEndsWithGrid->parseInput(&in);
+    manipulatorWithMatrixLast->parseInput(&in);
     EXPECT_THAT(A, Eq(123));
     EXPECT_THAT(V, Eq((vector<int>{42, 7})));
     EXPECT_THAT(M, Eq((vector<vector<int>>{{5, 6}, {7, 8}})));
 }
 
-TEST_F(IOManipulatorTests, Parsing_Empty_Failed_MissingEof) {
+TEST_F(IOManipulatorTests, Parsing_Failed_MissingEof_Empty) {
     istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
     try {
         manipulatorEmpty->parseInput(&in);
@@ -89,30 +89,30 @@ TEST_F(IOManipulatorTests, Parsing_Empty_Failed_MissingEof) {
     }
 }
 
-TEST_F(IOManipulatorTests, Parsing_EndsWithScalar_Failed_MissingEof) {
+TEST_F(IOManipulatorTests, Parsing_Failed_MissingEof_WithScalarLast) {
     istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
     try {
-        manipulatorEndsWithScalar->parseInput(&in);
+        manipulatorWithScalarLast->parseInput(&in);
         FAIL();
     } catch(runtime_error& e) {
         EXPECT_THAT(e.what(), StrEq("Expected: <EOF> after 'A'"));
     }
 }
 
-TEST_F(IOManipulatorTests, Parsing_EndsWithVector_Failed_MissingEof) {
+TEST_F(IOManipulatorTests, Parsing_Failed_MissingEof_WithVectorLast) {
     istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
     try {
-        manipulatorEndsWithVector->parseInput(&in);
+        manipulatorWithVectorLast->parseInput(&in);
         FAIL();
     } catch(runtime_error& e) {
         EXPECT_THAT(e.what(), StrEq("Expected: <EOF> after 'V[1]'"));
     }
 }
 
-TEST_F(IOManipulatorTests, Parsing_EndsWithGrid_Failed_MissingEof) {
+TEST_F(IOManipulatorTests, Parsing_Failed_MissingEof_WithMatrixLast) {
     istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
     try {
-        manipulatorEndsWithGrid->parseInput(&in);
+        manipulatorWithMatrixLast->parseInput(&in);
         FAIL();
     } catch(runtime_error& e) {
         EXPECT_THAT(e.what(), StrEq("Expected: <EOF> after 'M[1][1]'"));
@@ -124,7 +124,7 @@ TEST_F(IOManipulatorTests, Printing_Successful) {
     V = {42, 7};
     M = {{5, 6}, {7, 8}};
     ostringstream out;
-    manipulatorEndsWithGrid->printInput(&out);
+        manipulatorWithMatrixLast->printInput(&out);
     EXPECT_THAT(out.str(), Eq("123\n42\n7\n5 6\n7 8\n"));
 }
 

--- a/test/tcframe/io_manipulator/IOManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/IOManipulatorTests.cpp
@@ -52,7 +52,7 @@ TEST_F(IOManipulatorTests, Parsing_Failed_MissingEof) {
         manipulator->parseInput(&in);
         FAIL();
     } catch(runtime_error& e) {
-        EXPECT_THAT(e.what(), StrEq("Expected: <EOF>"));
+        EXPECT_THAT(e.what(), StrEq("Expected: <EOF> after 'M[1][1]'"));
     }
 }
 

--- a/test/tcframe/io_manipulator/IOManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/IOManipulatorTests.cpp
@@ -22,8 +22,16 @@ protected:
     IOManipulator* manipulatorEndsWithScalar;
     IOManipulator* manipulatorEndsWithVector;
     IOManipulator* manipulatorEndsWithGrid;
+    IOManipulator* manipulatorEmpty;
 
     void SetUp() {
+        {
+            IOFormatBuilder ioFormatBuilder;
+            ioFormatBuilder.prepareForInputFormat();
+            IOFormat ioFormat = ioFormatBuilder.build();
+
+            manipulatorEmpty = new IOManipulator(ioFormat);
+        }
         {
             IOFormatBuilder ioFormatBuilder;
             ioFormatBuilder.prepareForInputFormat();
@@ -69,6 +77,16 @@ TEST_F(IOManipulatorTests, Parsing_Successful) {
     EXPECT_THAT(A, Eq(123));
     EXPECT_THAT(V, Eq((vector<int>{42, 7})));
     EXPECT_THAT(M, Eq((vector<vector<int>>{{5, 6}, {7, 8}})));
+}
+
+TEST_F(IOManipulatorTests, Parsing_Empty_Failed_MissingEof) {
+    istringstream in("123\n42\n7\n5 6\n7 8\nbogus");
+    try {
+        manipulatorEmpty->parseInput(&in);
+        FAIL();
+    } catch(runtime_error& e) {
+        EXPECT_THAT(e.what(), StrEq("Expected: <EOF>"));
+    }
 }
 
 TEST_F(IOManipulatorTests, Parsing_EndsWithScalar_Failed_MissingEof) {

--- a/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
@@ -20,6 +20,10 @@ protected:
 
     int* size = new int(2);
 
+    LineIOSegment* segmentOnlyScalar = LineIOSegmentBuilder()
+            .addScalarVariable(Scalar::create(A, "A"))
+            .addScalarVariable(Scalar::create(B, "B"))
+            .build();
     LineIOSegment* segment = LineIOSegmentBuilder()
             .addScalarVariable(Scalar::create(A, "A"))
             .addScalarVariable(Scalar::create(B, "B"))
@@ -37,6 +41,20 @@ TEST_F(LineIOSegmentManipulatorTests, Parsing_EmptyLine) {
     istringstream in("\n");
 
     LineIOSegmentManipulator::parse(LineIOSegmentBuilder().build(), &in);
+}
+
+TEST_F(LineIOSegmentManipulatorTests, Parsing_OnlyScalar_Successful) {
+    istringstream in("42 123\n");
+
+    LineIOSegmentManipulator::parse(segmentOnlyScalar, &in);
+    EXPECT_THAT(A, Eq(42));
+    EXPECT_THAT(B, Eq(123));
+}
+
+TEST_F(LineIOSegmentManipulatorTests, Parsing_OnlyScalar_Successful_CheckLastVariable) {
+    istringstream in("42 123\n");
+
+    EXPECT_THAT(LineIOSegmentManipulator::parse(segmentOnlyScalar, &in), Eq("'B'"));
 }
 
 TEST_F(LineIOSegmentManipulatorTests, Parsing_Successful) {

--- a/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
@@ -48,6 +48,12 @@ TEST_F(LineIOSegmentManipulatorTests, Parsing_Successful) {
     EXPECT_THAT(C, Eq(vector<int>{1, 2}));
 }
 
+TEST_F(LineIOSegmentManipulatorTests, Parsing_Successful_CheckLastVariable) {
+    istringstream in("42 123 1 2\n");
+
+    EXPECT_THAT(LineIOSegmentManipulator::parse(segment, &in), Eq("'C[1]'"));
+}
+
 TEST_F(LineIOSegmentManipulatorTests, Parsing_Failed_MissingVariable) {
     istringstream in("42  ");
 
@@ -100,6 +106,12 @@ TEST_F(LineIOSegmentManipulatorTests, Parsing_WithVectorWithoutSize_Successful) 
     EXPECT_THAT(B, Eq(123));
     EXPECT_THAT(C, Eq(vector<int>{1, 2}));
     EXPECT_THAT(D, Eq(vector<int>{3, 4, 5}));
+}
+
+TEST_F(LineIOSegmentManipulatorTests, Parsing_WithVectorWithoutSize_Successful_CheckLastVariable) {
+    istringstream in("42 123 1 2 3 4 5\n");
+
+    EXPECT_THAT(LineIOSegmentManipulator::parse(segmentWithVectorWithoutSize, &in), Eq("'D[2]'"));
 }
 
 TEST_F(LineIOSegmentManipulatorTests, Parsing_WithVectorWithoutSize_Failed_MissingSpaceOrNewline) {

--- a/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
@@ -20,7 +20,7 @@ protected:
 
     int* size = new int(2);
 
-    LineIOSegment* segmentOnlyScalar = LineIOSegmentBuilder()
+    LineIOSegment* segmentWithScalarsOnly = LineIOSegmentBuilder()
             .addScalarVariable(Scalar::create(A, "A"))
             .addScalarVariable(Scalar::create(B, "B"))
             .build();
@@ -43,18 +43,18 @@ TEST_F(LineIOSegmentManipulatorTests, Parsing_EmptyLine) {
     LineIOSegmentManipulator::parse(LineIOSegmentBuilder().build(), &in);
 }
 
-TEST_F(LineIOSegmentManipulatorTests, Parsing_OnlyScalar_Successful) {
+TEST_F(LineIOSegmentManipulatorTests, Parsing_WithScalarsOnly_Successful) {
     istringstream in("42 123\n");
 
-    LineIOSegmentManipulator::parse(segmentOnlyScalar, &in);
+    LineIOSegmentManipulator::parse(segmentWithScalarsOnly, &in);
     EXPECT_THAT(A, Eq(42));
     EXPECT_THAT(B, Eq(123));
 }
 
-TEST_F(LineIOSegmentManipulatorTests, Parsing_OnlyScalar_Successful_CheckLastVariable) {
+TEST_F(LineIOSegmentManipulatorTests, Parsing_WithScalarsOnly_Successful_CheckLastVariable) {
     istringstream in("42 123\n");
 
-    EXPECT_THAT(LineIOSegmentManipulator::parse(segmentOnlyScalar, &in), Eq("'B'"));
+    EXPECT_THAT(LineIOSegmentManipulator::parse(segmentWithScalarsOnly, &in), Eq("'B'"));
 }
 
 TEST_F(LineIOSegmentManipulatorTests, Parsing_Successful) {

--- a/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
@@ -77,7 +77,18 @@ TEST_F(LineIOSegmentManipulatorTests, Parsing_Failed_MissingNewline) {
         LineIOSegmentManipulator::parse(segment, &in);
         FAIL();
     } catch (runtime_error& e) {
-        EXPECT_THAT(e.what(), StrEq("Expected: <newline> after 'C'"));
+        EXPECT_THAT(e.what(), StrEq("Expected: <newline> after 'C[1]'"));
+    }
+}
+
+TEST_F(LineIOSegmentManipulatorTests, Parsing_Failed_TooManyElements) {
+    istringstream in("42 123 1 2 3 4 5\n");
+
+    try {
+        LineIOSegmentManipulator::parse(segment, &in);
+        FAIL();
+    } catch (runtime_error& e) {
+        EXPECT_THAT(e.what(), StrEq("Expected: <newline> after 'C[1]'"));
     }
 }
 

--- a/test/tcframe/io_manipulator/LinesIOSegmentManipulatorTests.cpp
+++ b/test/tcframe/io_manipulator/LinesIOSegmentManipulatorTests.cpp
@@ -40,6 +40,12 @@ TEST_F(LinesIOSegmentManipulatorTests, Parsing_Successful) {
     EXPECT_THAT(Y, Eq(vector<int>{2, 4, 6}));
 }
 
+TEST_F(LinesIOSegmentManipulatorTests, Parsing_Successful_CheckLastVariable) {
+    istringstream in("1 2\n3 4\n5 6\n");
+
+    EXPECT_THAT(LinesIOSegmentManipulator::parse(segment, &in), Eq("'Y[2]'"));
+}
+
 TEST_F(LinesIOSegmentManipulatorTests, Parsing_Failed_MissingVariable) {
     istringstream in("1 2\n3  ");
 
@@ -80,6 +86,12 @@ TEST_F(LinesIOSegmentManipulatorTests, Parsing_WithJaggedVector_Successful) {
     EXPECT_THAT(X, Eq(vector<int>{1, 3, 5}));
     EXPECT_THAT(Y, Eq(vector<int>{2, 4, 6}));
     EXPECT_THAT(Z, Eq(vector<vector<int>>{{10}, {}, {20, 30}}));
+}
+
+TEST_F(LinesIOSegmentManipulatorTests, Parsing_WithJaggedVector_Successful_CheckLastVariable) {
+    istringstream in("1 2 10\n3 4\n5 6 20 30\n");
+
+    EXPECT_THAT(LinesIOSegmentManipulator::parse(segmentWithJaggedVector, &in), Eq("'Z[2][1]'"));
 }
 
 TEST_F(LinesIOSegmentManipulatorTests, Parsing_WithJaggedVector_Failed_MissingSpaceOrNewline) {


### PR DESCRIPTION
Fixed issue #15 