### PR TITLE
Fix regression when the final verdict of problem without subtasks is always AC

### DIFF
--- a/include/tcframe/grader/Grader.hpp
+++ b/include/tcframe/grader/Grader.hpp
@@ -10,6 +10,7 @@
 #include "GraderLogger.hpp"
 #include "TestCaseGrader.hpp"
 #include "tcframe/os.hpp"
+#include "tcframe/spec.hpp"
 #include "tcframe/util.hpp"
 #include "tcframe/verdict.hpp"
 
@@ -33,11 +34,11 @@ public:
             : testCaseGrader_(testCaseGrader)
             , logger_(logger) {}
 
-    virtual void grade(const TestSuite& testSuite, const set<int>& subtaskIds, const GraderConfig& config) {
+    virtual void grade(const TestSuite& testSuite, const ConstraintSuite& constraintSuite, const GraderConfig& config) {
         logger_->logIntroduction();
 
         map<int, Verdict> subtaskVerdicts;
-        for (int subtaskId : subtaskIds) {
+        for (int subtaskId : getSubtaskIdsToGrade(constraintSuite)) {
             subtaskVerdicts[subtaskId] = Verdict::ac();
         }
 
@@ -49,6 +50,20 @@ public:
     }
 
 private:
+    set<int> getSubtaskIdsToGrade(const ConstraintSuite& constraintSuite) {
+        set<int> subtaskIds;
+        for (const Subtask& subtask : constraintSuite.constraints()) {
+            subtaskIds.insert(subtask.id());
+        }
+
+        // remove global constraints for problem with subtasks
+        if (subtaskIds.size() > 1) {
+            subtaskIds.erase(-1);
+        }
+
+        return subtaskIds;
+    }
+
     void gradeOnTestGroup(
             const TestGroup& testGroup,
             const GraderConfig& config,

--- a/include/tcframe/runner/Runner.hpp
+++ b/include/tcframe/runner/Runner.hpp
@@ -149,12 +149,7 @@ private:
         auto testCaseGrader = new TestCaseGrader(evaluator, scorer, logger);
         auto grader = graderFactory_->create(testCaseGrader, logger);
 
-        set<int> subtaskIds;
-        for (const Subtask& subtask : spec.constraintSuite().constraints()) {
-            subtaskIds.insert(subtask.id());
-        }
-
-        grader->grade(spec.testSuite(), subtaskIds, graderConfig);
+        grader->grade(spec.testSuite(), spec.constraintSuite(), graderConfig);
         return 0;
     }
 

--- a/include/tcframe/spec/testcase/TestSuite.hpp
+++ b/include/tcframe/spec/testcase/TestSuite.hpp
@@ -67,8 +67,8 @@ public:
     TestSuiteBuilder()
             : beforeClosure_([]{})
             , afterClosure_([]{})
-            , curSampleSubtaskIds_({})
-            , curOfficialSubtaskIds_({})
+            , curSampleSubtaskIds_({-1})
+            , curOfficialSubtaskIds_({-1})
             , curOfficialTestGroupId_(-1)
             , hasCurOfficialTestGroup_(false)
             , hasCurSampleTestCase_(false) {
@@ -95,7 +95,7 @@ public:
         }
 
         hasCurSampleTestCase_ = true;
-        curSampleSubtaskIds_ = {};
+        curSampleSubtaskIds_ = {-1};
         curSubtaskIds_ = &curSampleSubtaskIds_;
         curSampleInputLines_ = optional<vector<string>>();
         curSampleOutputLines_ = optional<vector<string>>();

--- a/test/tcframe/grader/MockGrader.hpp
+++ b/test/tcframe/grader/MockGrader.hpp
@@ -11,7 +11,7 @@ public:
     MockGrader()
             : Grader(nullptr, nullptr) {}
 
-    MOCK_METHOD3(grade, void(const TestSuite&, const set<int>&, const GraderConfig&));
+    MOCK_METHOD3(grade, void(const TestSuite&, const ConstraintSuite&, const GraderConfig&));
 };
 
 class MockGraderFactory : public GraderFactory {

--- a/test/tcframe/spec/testcase/TestSuiteBuilderTests.cpp
+++ b/test/tcframe/spec/testcase/TestSuiteBuilderTests.cpp
@@ -58,12 +58,12 @@ TEST_F(TestSuiteBuilderTests, Building_OnlySample) {
             TestGroup(0, {
                     TestCaseBuilder()
                             .setId("foo_sample_1")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setData(new SampleTestCaseData("10\n20\n", "yes\n"))
                             .build(),
                     TestCaseBuilder()
                             .setId("foo_sample_2")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setData(new SampleTestCaseData("30\n"))
                             .build()})});
 
@@ -82,13 +82,13 @@ TEST_F(TestSuiteBuilderTests, Building_OnlyOfficial) {
             TestGroup(-1, {
                     TestCaseBuilder()
                             .setId("foo_1")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setDescription("N = 1")
                             .setData(new OfficialTestCaseData([]{}))
                             .build(),
                     TestCaseBuilder()
                             .setId("foo_2")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setDescription("N = 2")
                             .setData(new OfficialTestCaseData([]{}))
                             .build()})});
@@ -120,24 +120,24 @@ TEST_F(TestSuiteBuilderTests, Building_Both) {
             TestGroup(0, {
                     TestCaseBuilder()
                             .setId("foo_sample_1")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setData(new SampleTestCaseData("10\n20\n", "yes\n"))
                             .build(),
                     TestCaseBuilder()
                             .setId("foo_sample_2")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setData(new SampleTestCaseData("30\n"))
                             .build()}),
             TestGroup(-1, {
                     TestCaseBuilder()
                             .setId("foo_1")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setDescription("N = 1")
                             .setData(new OfficialTestCaseData([]{}))
                             .build(),
                     TestCaseBuilder()
                             .setId("foo_2")
-                            .setSubtaskIds({})
+                            .setSubtaskIds({-1})
                             .setDescription("N = 2")
                             .setData(new OfficialTestCaseData([]{}))
                             .build()})});


### PR DESCRIPTION
This was introduced by the global constraints feature in 1.0.
The problem is we were using -1 as the key of subtask ID in the verdict map,
but we removed it.