### PR TITLE
Fix regression for segment sizes with expressions containing variables

### DIFF
--- a/include/tcframe/io_manipulator/GridIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/GridIOSegmentManipulator.hpp
@@ -19,7 +19,7 @@ public:
     static string parse(GridIOSegment* segment, istream* in) {
         Matrix* variable = segment->variable();
         variable->clear();
-        variable->parseFrom(in, *segment->rows(), *segment->columns());
+        variable->parseFrom(in, segment->rows()(), segment->columns()());
 
         return TokenFormatter::formatMatrixElement(variable->name(),
                                                    variable->rows() - 1,
@@ -36,19 +36,21 @@ public:
 private:
     static void checkMatrixSize(GridIOSegment* segment) {
         Matrix* variable = segment->variable();
+        int expectedRows = segment->rows()();
+        int expectedColumns = segment->columns()();
 
-        if (variable->rows() != *segment->rows()) {
+        if (variable->rows() != expectedRows) {
             throw runtime_error(
                     "Number of rows of matrix " + TokenFormatter::formatVariable(variable->name())
-                    + " unsatisfied. Expected: " + StringUtils::toString(*segment->rows())
+                    + " unsatisfied. Expected: " + StringUtils::toString(expectedRows)
                     + ", actual: " + StringUtils::toString(variable->rows()));
         }
         for (int r = 0; r < variable->rows(); r++) {
-            if (variable->columns(r) != *segment->columns()) {
+            if (variable->columns(r) != expectedColumns) {
                 throw runtime_error(
                         "Number of columns of row " + StringUtils::toString(r)
                         + " of matrix " + TokenFormatter::formatVariable(variable->name())
-                        + " unsatisfied. Expected: " + StringUtils::toString(*segment->columns())
+                        + " unsatisfied. Expected: " + StringUtils::toString(expectedColumns)
                         + ", actual: " + StringUtils::toString(variable->columns(r)));
             }
         }

--- a/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
@@ -62,7 +62,7 @@ public:
 
 private:
     static void checkVectorSize(Vector* vektor, int size) {
-        if (size != -1 && vektor->size() != size) {
+        if (size != NO_SIZE && vektor->size() != size) {
             throw runtime_error("Number of elements of vector " + TokenFormatter::formatVariable(vektor->name())
                                 + " unsatisfied. Expected: " + StringUtils::toString(size) + ", actual: "
                                 + StringUtils::toString(vektor->size()));
@@ -75,7 +75,7 @@ private:
 
     static void parseVector(Vector* vektor, int size, istream* in) {
         vektor->clear();
-        if (size == -1) {
+        if (size == NO_SIZE) {
             vektor->parseFrom(in);
         } else {
             vektor->parseFrom(in, size);

--- a/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LineIOSegmentManipulator.hpp
@@ -24,7 +24,7 @@ public:
             }
 
             Variable* variable = segmentVariable.variable();
-            int size = *segmentVariable.size();
+            int size = segmentVariable.size()();
 
             if (variable->type() == VariableType::SCALAR) {
                 parseScalar((Scalar*) variable, in);
@@ -49,7 +49,7 @@ public:
             first = false;
 
             Variable* variable = segmentVariable.variable();
-            int size = *segmentVariable.size();
+            int size = segmentVariable.size()();
 
             if (variable->type() == VariableType::SCALAR) {
                 printScalar((Scalar*) variable, out);

--- a/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
@@ -29,7 +29,7 @@ public:
 
         int size = segment->size()();
         for (int j = 0; j != size; j++) {
-            if (size == -1 && WhitespaceManipulator::isEof(in)) {
+            if (size == NO_SIZE && WhitespaceManipulator::isEof(in)) {
                 break;
             }
 
@@ -85,7 +85,7 @@ public:
 private:
     static int getSize(LinesIOSegment* segment) {
         int size = segment->size()();
-        if (size != -1) {
+        if (size != NO_SIZE) {
             return size;
         }
 
@@ -112,7 +112,7 @@ private:
             }
             if (size != expectedSize) {
                 string withoutSizeMessage;
-                if (segment->size()() == -1) {
+                if (segment->size()() == NO_SIZE) {
                     string firstVariableName = TokenFormatter::formatVariable(segment->variables()[0]->name());
                     withoutSizeMessage = " (number of elements of " + firstVariableName + ")";
                 }

--- a/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/LinesIOSegmentManipulator.hpp
@@ -27,8 +27,9 @@ public:
 
         string lastVariableName;
 
-        for (int j = 0; j != *segment->size(); j++) {
-            if (*segment->size() == -1 && WhitespaceManipulator::isEof(in)) {
+        int size = segment->size()();
+        for (int j = 0; j != size; j++) {
+            if (size == -1 && WhitespaceManipulator::isEof(in)) {
                 break;
             }
 
@@ -83,8 +84,9 @@ public:
 
 private:
     static int getSize(LinesIOSegment* segment) {
-        if (*segment->size() != -1) {
-            return *segment->size();
+        int size = segment->size()();
+        if (size != -1) {
+            return size;
         }
 
         Variable* firstVariable = segment->variables()[0];
@@ -110,7 +112,7 @@ private:
             }
             if (size != expectedSize) {
                 string withoutSizeMessage;
-                if (*segment->size() == -1) {
+                if (segment->size()() == -1) {
                     string firstVariableName = TokenFormatter::formatVariable(segment->variables()[0]->name());
                     withoutSizeMessage = " (number of elements of " + firstVariableName + ")";
                 }

--- a/include/tcframe/io_manipulator/RawLinesIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/RawLinesIOSegmentManipulator.hpp
@@ -20,8 +20,9 @@ public:
         string lastVariableName;
 
         Vector* variable = segment->variable();
-        for (int j = 0; j != *segment->size(); j++) {
-            if (*segment->size() == -1 && WhitespaceManipulator::isEof(in)) {
+        int size = segment->size()();
+        for (int j = 0; j != size; j++) {
+            if (size == -1 && WhitespaceManipulator::isEof(in)) {
                 break;
             }
 
@@ -46,10 +47,11 @@ public:
 private:
     static void checkVectorSize(RawLinesIOSegment* segment) {
         Vector* variable = segment->variable();
-        if (*segment->size() != -1 && *segment->size() != variable->size()) {
+        int expectedSize = segment->size()();
+        if (expectedSize != -1 && expectedSize != variable->size()) {
             throw runtime_error(
                     "Number of elements of " + TokenFormatter::formatVariable(variable->name())
-                    + " unsatisfied. Expected: " + StringUtils::toString(*segment->size())
+                    + " unsatisfied. Expected: " + StringUtils::toString(expectedSize)
                     + ", actual: " + StringUtils::toString(variable->size()));
         }
     }

--- a/include/tcframe/io_manipulator/RawLinesIOSegmentManipulator.hpp
+++ b/include/tcframe/io_manipulator/RawLinesIOSegmentManipulator.hpp
@@ -22,7 +22,7 @@ public:
         Vector* variable = segment->variable();
         int size = segment->size()();
         for (int j = 0; j != size; j++) {
-            if (size == -1 && WhitespaceManipulator::isEof(in)) {
+            if (size == NO_SIZE && WhitespaceManipulator::isEof(in)) {
                 break;
             }
 
@@ -48,7 +48,7 @@ private:
     static void checkVectorSize(RawLinesIOSegment* segment) {
         Vector* variable = segment->variable();
         int expectedSize = segment->size()();
-        if (expectedSize != -1 && expectedSize != variable->size()) {
+        if (expectedSize != NO_SIZE && expectedSize != variable->size()) {
             throw runtime_error(
                     "Number of elements of " + TokenFormatter::formatVariable(variable->name())
                     + " unsatisfied. Expected: " + StringUtils::toString(expectedSize)

--- a/include/tcframe/spec/core/Magic.hpp
+++ b/include/tcframe/spec/core/Magic.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <queue>
 #include <string>
 #include <vector>
@@ -9,6 +10,7 @@
 #include "tcframe/spec/variable.hpp"
 #include "tcframe/util.hpp"
 
+using std::function;
 using std::queue;
 using std::string;
 using std::vector;
@@ -22,8 +24,8 @@ using std::vector;
 #define RAW_LINES(...) (MagicRawLinesIOSegmentBuilder(newRawLinesIOSegment(), #__VA_ARGS__), __VA_ARGS__)
 #define GRID(...) (MagicGridIOSegmentBuilder(newGridIOSegment(), #__VA_ARGS__), __VA_ARGS__)
 
-#define SIZE_IMPL1(size) VectorSize(size)
-#define SIZE_IMPL2(rows, columns) MatrixSize(rows, columns)
+#define SIZE_IMPL1(size) VectorSize([=] {return size;})
+#define SIZE_IMPL2(rows, columns) MatrixSize([=] {return rows;}, [=] {return columns;})
 #define SIZE_WITH_COUNT(_1, _2, N, ...) SIZE_IMPL ## N
 #define SIZE(...) SIZE_WITH_COUNT(__VA_ARGS__, 2, 1)(__VA_ARGS__)
 
@@ -31,13 +33,10 @@ using std::vector;
 namespace tcframe {
 
 struct VectorSize {
-    int* size;
+    function<int()> size;
 
-    VectorSize(int&& size)
-            : size(new int(size)) {}
-
-    VectorSize(int& size)
-            : size(&size) {}
+    VectorSize(const function<int()>& size)
+            : size(size) {}
 };
 
 template<typename T>
@@ -52,24 +51,12 @@ VectorWithSize<T> operator%(vector<T>& vektor, VectorSize size) {
 }
 
 struct MatrixSize {
-    int* rows;
-    int* columns;
+    function<int()> rows;
+    function<int()> columns;
 
-    MatrixSize(int&& rows, int&& columns)
-            : rows(new int(rows))
-            , columns(new int(columns)) {}
-
-    MatrixSize(int&& rows, int& columns)
-            : rows(new int(rows))
-            , columns(&columns) {}
-
-    MatrixSize(int& rows, int&& columns)
-            : rows(&rows)
-            , columns(new int(columns)) {}
-
-    MatrixSize(int& rows, int& columns)
-            : rows(&rows)
-            , columns(&columns) {}
+    MatrixSize(const function<int()>& rows, const function<int()>& columns)
+            : rows(rows)
+            , columns(columns) {}
 };
 
 class VariableNamesExtractor {

--- a/include/tcframe/spec/io/GridIOSegment.hpp
+++ b/include/tcframe/spec/io/GridIOSegment.hpp
@@ -25,8 +25,8 @@ private:
 public:
     GridIOSegment()
             : variable_(nullptr)
-            , rows_([] {return -1;})
-            , columns_([] {return -1;}) {}
+            , rows_([] {return NO_SIZE;})
+            , columns_([] {return NO_SIZE;}) {}
 
     IOSegmentType type() const {
         return IOSegmentType::GRID;
@@ -97,7 +97,7 @@ private:
         if (subject_->variable_ == nullptr) {
             throw runtime_error("Grid segment must have exactly one variable");
         }
-        if (subject_->rows_() == -1 || subject_->columns_() == -1) {
+        if (subject_->rows_() == NO_SIZE || subject_->columns_() == NO_SIZE) {
             throw runtime_error("Grid segment must define matrix sizes");
         }
     }

--- a/include/tcframe/spec/io/IOFormat.hpp
+++ b/include/tcframe/spec/io/IOFormat.hpp
@@ -141,14 +141,14 @@ private:
         if (segment->type() != IOSegmentType::LINES) {
             return false;
         }
-        return *((LinesIOSegment*) segment)->size() == -1;
+        return ((LinesIOSegment*) segment)->size()() == -1;
     }
 
     bool isRawLinesSegmentWithoutSize(IOSegment* segment) {
         if (segment->type() != IOSegmentType::RAW_LINES) {
             return false;
         }
-        return *((RawLinesIOSegment*) segment)->size() == -1;
+        return ((RawLinesIOSegment*) segment)->size()() == -1;
     }
 };
 

--- a/include/tcframe/spec/io/IOFormat.hpp
+++ b/include/tcframe/spec/io/IOFormat.hpp
@@ -141,14 +141,14 @@ private:
         if (segment->type() != IOSegmentType::LINES) {
             return false;
         }
-        return ((LinesIOSegment*) segment)->size()() == -1;
+        return ((LinesIOSegment*) segment)->size()() == NO_SIZE;
     }
 
     bool isRawLinesSegmentWithoutSize(IOSegment* segment) {
         if (segment->type() != IOSegmentType::RAW_LINES) {
             return false;
         }
-        return ((RawLinesIOSegment*) segment)->size()() == -1;
+        return ((RawLinesIOSegment*) segment)->size()() == NO_SIZE;
     }
 };
 

--- a/include/tcframe/spec/io/IOSegment.hpp
+++ b/include/tcframe/spec/io/IOSegment.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <climits>
+
 namespace tcframe {
+
+const int NO_SIZE = INT_MIN;
 
 enum class IOSegmentType {
     GRID,

--- a/include/tcframe/spec/io/LineIOSegment.hpp
+++ b/include/tcframe/spec/io/LineIOSegment.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -7,6 +8,7 @@
 #include "IOSegment.hpp"
 #include "tcframe/spec/variable.hpp"
 
+using std::function;
 using std::runtime_error;
 using std::tie;
 using std::vector;
@@ -16,28 +18,28 @@ namespace tcframe {
 struct LineIOSegmentVariable {
 private:
     Variable* variable_;
-    int* size_;
+    function<int()> size_;
 
 public:
-    LineIOSegmentVariable(Variable* variable, int* size)
+    LineIOSegmentVariable(Variable* variable, const function<int()>& size)
             : variable_(variable)
             , size_(size) {}
 
     LineIOSegmentVariable(Variable* variable)
             : variable_(variable)
-            , size_(new int(-1)) {
+            , size_([] {return -1;}) {
     }
 
     Variable* variable() const {
         return variable_;
     }
 
-    int* size() const {
+    const function<int()>& size() const {
         return size_;
     }
 
     bool operator==(const LineIOSegmentVariable& o) const {
-        return variable_->equals(o.variable_) && *size_ == *o.size_;
+        return variable_->equals(o.variable_) && size_() == o.size_();
     }
 };
 
@@ -88,7 +90,7 @@ public:
         return *this;
     }
 
-    LineIOSegmentBuilder& addVectorVariable(Vector* variable, int* size) {
+    LineIOSegmentBuilder& addVectorVariable(Vector* variable, function<int()> size) {
         checkVectorWithoutSize();
         subject_->variables_.push_back(LineIOSegmentVariable(variable, size));
         return *this;

--- a/include/tcframe/spec/io/LineIOSegment.hpp
+++ b/include/tcframe/spec/io/LineIOSegment.hpp
@@ -27,7 +27,7 @@ public:
 
     LineIOSegmentVariable(Variable* variable)
             : variable_(variable)
-            , size_([] {return -1;}) {
+            , size_([] {return NO_SIZE;}) {
     }
 
     Variable* variable() const {

--- a/include/tcframe/spec/io/LinesIOSegment.hpp
+++ b/include/tcframe/spec/io/LinesIOSegment.hpp
@@ -62,7 +62,7 @@ private:
 public:
     LinesIOSegmentBuilder()
             : subject_(new LinesIOSegment()) {
-        subject_->size_ = [] {return -1;};
+        subject_->size_ = [] {return NO_SIZE;};
     }
 
     LinesIOSegmentBuilder& addVectorVariable(Vector* variable) {

--- a/include/tcframe/spec/io/LinesIOSegment.hpp
+++ b/include/tcframe/spec/io/LinesIOSegment.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -7,6 +8,7 @@
 #include "IOSegment.hpp"
 #include "tcframe/spec/variable.hpp"
 
+using std::function;
 using std::runtime_error;
 using std::tie;
 using std::vector;
@@ -18,7 +20,7 @@ struct LinesIOSegment : public IOSegment {
 
 private:
     vector<Variable*> variables_;
-    int* size_;
+    function<int()> size_;
 
 public:
     IOSegmentType type() const {
@@ -29,12 +31,12 @@ public:
         return variables_;
     }
 
-    int* size() const {
+    const function<int()>& size() const {
         return size_;
     }
 
     bool operator==(const LinesIOSegment& o) const {
-        if (*size_ != *o.size_) {
+        if (size_() != o.size_()) {
             return false;
         }
         if (variables_.size() != o.variables_.size()) {
@@ -60,7 +62,7 @@ private:
 public:
     LinesIOSegmentBuilder()
             : subject_(new LinesIOSegment()) {
-        subject_->size_ = new int(-1);
+        subject_->size_ = [] {return -1;};
     }
 
     LinesIOSegmentBuilder& addVectorVariable(Vector* variable) {
@@ -75,7 +77,7 @@ public:
         return *this;
     }
 
-    LinesIOSegmentBuilder& setSize(int* size) {
+    LinesIOSegmentBuilder& setSize(function<int()> size) {
         subject_->size_ = size;
         return *this;
     }

--- a/include/tcframe/spec/io/RawLinesIOSegment.hpp
+++ b/include/tcframe/spec/io/RawLinesIOSegment.hpp
@@ -51,7 +51,7 @@ private:
 public:
     RawLinesIOSegmentBuilder()
             : subject_(new RawLinesIOSegment()) {
-        subject_->size_ = [] {return -1;};
+        subject_->size_ = [] {return NO_SIZE;};
     }
 
     RawLinesIOSegmentBuilder& addVectorVariable(Vector* variable) {

--- a/include/tcframe/spec/io/RawLinesIOSegment.hpp
+++ b/include/tcframe/spec/io/RawLinesIOSegment.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -7,6 +8,7 @@
 #include "IOSegment.hpp"
 #include "tcframe/spec/variable.hpp"
 
+using std::function;
 using std::runtime_error;
 using std::tie;
 using std::vector;
@@ -18,7 +20,7 @@ struct RawLinesIOSegment : public IOSegment {
 
 private:
     Vector* variable_;
-    int* size_;
+    function<int()> size_;
 
 public:
     IOSegmentType type() const {
@@ -29,12 +31,12 @@ public:
         return variable_;
     }
 
-    int* size() const {
+    const function<int()>& size() const {
         return size_;
     }
 
     bool operator==(const RawLinesIOSegment& o) const {
-        return *size_ == *o.size_ && variable_->equals(o.variable_);
+        return size_() == o.size_() && variable_->equals(o.variable_);
     }
 
     bool equals(IOSegment* o) const {
@@ -49,7 +51,7 @@ private:
 public:
     RawLinesIOSegmentBuilder()
             : subject_(new RawLinesIOSegment()) {
-        subject_->size_ = new int(-1);
+        subject_->size_ = [] {return -1;};
     }
 
     RawLinesIOSegmentBuilder& addVectorVariable(Vector* variable) {
@@ -58,7 +60,7 @@ public:
         return *this;
     }
 
-    RawLinesIOSegmentBuilder& setSize(int* size) {
+    RawLinesIOSegmentBuilder& setSize(function<int()> size) {
         subject_->size_ = size;
         return *this;
     }

--- a/test/ete/resources/normal-complex-formats/spec.cpp
+++ b/test/ete/resources/normal-complex-formats/spec.cpp
@@ -19,7 +19,7 @@ protected:
         RAW_LINE(S);
         LINE(N);
         LINE(A % SIZE(2));
-        LINES(X, Y) % SIZE(N + 1);
+        LINES(X, Y) % SIZE(N - 1);
         GRID(M) % SIZE(2, 3);
     }
 
@@ -43,11 +43,10 @@ protected:
     void SampleTestCase1() {
         Input({
             "[BEGIN INPUT]",
-            "2",
+            "3",
             "3 5",
             "1 1",
             "2 2",
-            "3 3",
             "7 7 7",
             "8 8 8"
         });
@@ -59,6 +58,6 @@ protected:
     }
 
     void TestCases() {
-        CASE(S = "[BEGIN INPUT]", N = 2, A = {10, 20}, X = {0, 0, 0}, Y = {1, 1, 1}, M = { {1, 2, 3}, {4, 5, 6} });
+        CASE(S = "[BEGIN INPUT]", N = 3, A = {10, 20}, X = {0, 0}, Y = {1, 1}, M = { {1, 2, 3}, {4, 5, 6} });
     }
 };

--- a/test/ete/resources/normal-complex-formats/spec.cpp
+++ b/test/ete/resources/normal-complex-formats/spec.cpp
@@ -19,7 +19,7 @@ protected:
         RAW_LINE(S);
         LINE(N);
         LINE(A % SIZE(2));
-        LINES(X, Y) % SIZE(N);
+        LINES(X, Y) % SIZE(N + 1);
         GRID(M) % SIZE(2, 3);
     }
 
@@ -47,6 +47,7 @@ protected:
             "3 5",
             "1 1",
             "2 2",
+            "3 3",
             "7 7 7",
             "8 8 8"
         });
@@ -58,6 +59,6 @@ protected:
     }
 
     void TestCases() {
-        CASE(S = "[BEGIN INPUT]", N = 2, A = {10, 20}, X = {0, 0}, Y = {1, 1}, M = { {1, 2, 3}, {4, 5, 6} });
+        CASE(S = "[BEGIN INPUT]", N = 2, A = {10, 20}, X = {0, 0, 0}, Y = {1, 1, 1}, M = { {1, 2, 3}, {4, 5, 6} });
     }
 };

--- a/test/unit/tcframe/io_manipulator/GridIOSegmentManipulatorTests.cpp
+++ b/test/unit/tcframe/io_manipulator/GridIOSegmentManipulatorTests.cpp
@@ -15,8 +15,8 @@ namespace tcframe {
 
 class GridIOSegmentManipulatorTests : public Test {
 protected:
-    int* rows = new int(2);
-    int* columns = new int(3);
+    function<int()> rows = [] {return 2;};
+    function<int()> columns = [] {return 3;};
 
     vector<vector<int>> M;
     GridIOSegment* segment = GridIOSegmentBuilder()

--- a/test/unit/tcframe/io_manipulator/IOManipulatorTests.cpp
+++ b/test/unit/tcframe/io_manipulator/IOManipulatorTests.cpp
@@ -50,7 +50,7 @@ protected:
                     .addScalarVariable(Scalar::create(A, "A"));
             ioFormatBuilder.newLinesIOSegment()
                     .addVectorVariable(Vector::create(V, "V"))
-                    .setSize(new int(2));
+                    .setSize([] {return 2;});
             IOFormat ioFormat = ioFormatBuilder.build();
 
             manipulatorWithVectorLast = new IOManipulator(ioFormat);
@@ -64,13 +64,13 @@ protected:
                     .addScalarVariable(Scalar::createRaw(S, "S"));
             ioFormatBuilder.newLinesIOSegment()
                     .addVectorVariable(Vector::create(V, "V"))
-                    .setSize(new int(2));
+                    .setSize([] {return 2;});
             ioFormatBuilder.newRawLinesIOSegment()
                     .addVectorVariable(Vector::createRaw(W, "W"))
-                    .setSize(new int(2));
+                    .setSize([] {return 2;});
             ioFormatBuilder.newGridIOSegment()
                     .addMatrixVariable(Matrix::create(M, "M"))
-                    .setSize(new int(2), new int(2));
+                    .setSize([] {return 2;}, [] {return 2;});
             IOFormat ioFormat = ioFormatBuilder.build();
 
             manipulatorWithMatrixLast = new IOManipulator(ioFormat);

--- a/test/unit/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
+++ b/test/unit/tcframe/io_manipulator/LineIOSegmentManipulatorTests.cpp
@@ -18,7 +18,7 @@ protected:
     int A, B;
     vector<int> C, D;
 
-    int* size = new int(2);
+    function<int()> size = [] {return 2;};
 
     LineIOSegment* segmentWithScalarsOnly = LineIOSegmentBuilder()
             .addScalarVariable(Scalar::create(A, "A"))

--- a/test/unit/tcframe/io_manipulator/LinesIOSegmentManipulatorTests.cpp
+++ b/test/unit/tcframe/io_manipulator/LinesIOSegmentManipulatorTests.cpp
@@ -17,7 +17,7 @@ class LinesIOSegmentManipulatorTests : public Test {
 protected:
     vector<int> X, Y;
     vector<vector<int>> Z;
-    int* size = new int(3);
+    function<int()> size = [] {return 3;};
 
     LinesIOSegment* segment = LinesIOSegmentBuilder()
             .addVectorVariable(Vector::create(X, "X"))

--- a/test/unit/tcframe/io_manipulator/RawLinesIOSegmentManipulatorTests.cpp
+++ b/test/unit/tcframe/io_manipulator/RawLinesIOSegmentManipulatorTests.cpp
@@ -16,7 +16,7 @@ namespace tcframe {
 class RawLinesIOSegmentManipulatorTests : public Test {
 protected:
     vector<string> V;
-    int* size = new int(2);
+    function<int()> size = [] {return 2;};
 
     RawLinesIOSegment* segment = RawLinesIOSegmentBuilder()
             .addVectorVariable(Vector::createRaw(V, "V"))

--- a/test/unit/tcframe/spec/core/BaseProblemSpecTests.cpp
+++ b/test/unit/tcframe/spec/core/BaseProblemSpecTests.cpp
@@ -28,20 +28,20 @@ protected:
                     .addScalarVariable(Scalar::create(B, "B"));
             newLinesIOSegment()
                     .addVectorVariable(Vector::create(X, "X"))
-                    .setSize(new int(3));
+                    .setSize([] {return 3;});
             newGridIOSegment()
                     .addMatrixVariable(Matrix::create(M, "M"))
-                    .setSize(new int(2), new int(3))
+                    .setSize([] {return 2;}, [] {return 3;})
                     .build();
         }
 
         void OutputFormat() {
             newLinesIOSegment()
                     .addVectorVariable(Vector::create(X, "X"))
-                    .setSize(new int(3));
+                    .setSize([] {return 3;});
             newGridIOSegment()
                     .addMatrixVariable(Matrix::create(M, "M"))
-                    .setSize(new int(2), new int(3))
+                    .setSize([] {return 2;}, [] {return 3;})
                     .build();
             newLineIOSegment()
                     .addScalarVariable(Scalar::create(A, "A"))

--- a/test/unit/tcframe/spec/core/MagicTests.cpp
+++ b/test/unit/tcframe/spec/core/MagicTests.cpp
@@ -180,11 +180,11 @@ TEST_F(MagicTests, LINE_Valid) {
             .addScalarVariable(Scalar::create(dummy, "A"))
             .addScalarVariable(Scalar::create(dummy, "B"));
     builder.newLineIOSegment()
-            .addVectorVariable(Vector::create(dummy2, "C"), new int(3));
+            .addVectorVariable(Vector::create(dummy2, "C"), [] {return 3;});
     builder.newLineIOSegment()
             .addScalarVariable(Scalar::create(dummy, "A"))
             .addScalarVariable(Scalar::create(dummy, "B"))
-            .addVectorVariable(Vector::create(dummy2, "C"), new int(3))
+            .addVectorVariable(Vector::create(dummy2, "C"), [] {return 3;})
             .addVectorVariable(Vector::create(dummy2, "D"));
 
     EXPECT_THAT(ioFormat, Eq(builder.build()));
@@ -215,16 +215,16 @@ TEST_F(MagicTests, LINES_Valid) {
     builder.prepareForInputFormat();
     builder.newLinesIOSegment()
             .addVectorVariable(Vector::create(dummy, "X"))
-            .setSize(new int(2));
+            .setSize([] {return 2;});
     builder.newLinesIOSegment()
             .addVectorVariable(Vector::create(dummy, "X"))
             .addVectorVariable(Vector::create(dummy, "Y"))
-            .setSize(new int(3));
+            .setSize([] {return 3;});
     builder.newLinesIOSegment()
             .addVectorVariable(Vector::create(dummy, "X"))
             .addVectorVariable(Vector::create(dummy, "Y"))
             .addJaggedVectorVariable(Matrix::create(dummy2, "Z"))
-            .setSize(new int(4));
+            .setSize([] {return 4;});
     builder.newLinesIOSegment()
             .addVectorVariable(Vector::create(dummy, "A"))
             .addVectorVariable(Vector::create(dummy, "B"))
@@ -285,10 +285,10 @@ TEST_F(MagicTests, RAW_LINES_Valid) {
     builder.prepareForInputFormat();
     builder.newRawLinesIOSegment()
             .addVectorVariable(Vector::createRaw(dummy, "X"))
-            .setSize(new int(2));
+            .setSize([] {return 2;});
     builder.newRawLinesIOSegment()
             .addVectorVariable(Vector::createRaw(dummy, "Y"))
-            .setSize(new int(3));
+            .setSize([] {return 3;});
     builder.newRawLinesIOSegment()
             .addVectorVariable(Vector::createRaw(dummy, "Z"));
 
@@ -319,16 +319,16 @@ TEST_F(MagicTests, GRID_Valid) {
     builder.prepareForInputFormat();
     builder.newGridIOSegment()
             .addMatrixVariable(Matrix::create(dummy, "M1"))
-            .setSize(new int(2), new int(3));
+            .setSize([] {return 2;}, [] {return 3;});
     builder.newGridIOSegment()
             .addMatrixVariable(Matrix::create(dummy, "M2"))
-            .setSize(new int(2), new int(3));
+            .setSize([] {return 2;}, [] {return 3;});
     builder.newGridIOSegment()
             .addMatrixVariable(Matrix::create(dummy, "M3"))
-            .setSize(new int(2), new int(3));
+            .setSize([] {return 2;}, [] {return 3;});
     builder.newGridIOSegment()
             .addMatrixVariable(Matrix::create(dummy, "M4"))
-            .setSize(new int(2), new int(3));
+            .setSize([] {return 2;}, [] {return 3;});
 
     EXPECT_THAT(ioFormat, Eq(builder.build()));
 }

--- a/test/unit/tcframe/spec/io/GridIOSegmentBuilderTests.cpp
+++ b/test/unit/tcframe/spec/io/GridIOSegmentBuilderTests.cpp
@@ -18,18 +18,18 @@ protected:
 TEST_F(GridIOSegmentBuilderTests, Building_Successful) {
     GridIOSegment* segment = builder
             .addMatrixVariable(Matrix::create(M, "M"))
-            .setSize(new int(2), new int(3))
+            .setSize([] {return 2;}, [] {return 3;})
             .build();
 
     EXPECT_TRUE(segment->variable()->equals(Matrix::create(M, "M")));
-    EXPECT_THAT(*segment->rows(), Eq(2));
-    EXPECT_THAT(*segment->columns(), Eq(3));
+    EXPECT_THAT(segment->rows()(), Eq(2));
+    EXPECT_THAT(segment->columns()(), Eq(3));
 }
 
 TEST_F(GridIOSegmentBuilderTests, Building_Failed_NoVariables) {
     try {
         builder
-                .setSize(new int(2), new int(3))
+                .setSize([] {return 2;}, [] {return 3;})
                 .build();
         FAIL();
     } catch (runtime_error& e) {
@@ -42,7 +42,7 @@ TEST_F(GridIOSegmentBuilderTests, Building_Failed_MultipleVariables) {
         builder
                 .addMatrixVariable(Matrix::create(M, "M"))
                 .addMatrixVariable(Matrix::create(N, "N"))
-                .setSize(new int(2), new int(3))
+                .setSize([] {return 2;}, [] {return 3;})
                 .build();
         FAIL();
     } catch (runtime_error& e) {

--- a/test/unit/tcframe/spec/io/IOFormatBuilderTests.cpp
+++ b/test/unit/tcframe/spec/io/IOFormatBuilderTests.cpp
@@ -31,27 +31,27 @@ TEST_F(IOFormatBuilderTests, Building_Successful) {
     builder
             .newLinesIOSegment()
             .addVectorVariable(Vector::create(Y, "Y"))
-            .setSize(new int(3));
+            .setSize([] {return 3;});
     builder
             .newGridIOSegment()
             .addMatrixVariable(Matrix::create(Z, "Z"))
-            .setSize(new int(2), new int(3))
+            .setSize([] {return 2;}, [] {return 3;})
             .build();
 
     builder.prepareForOutputFormat();
     builder
             .newGridIOSegment()
             .addMatrixVariable(Matrix::create(Z, "Z"))
-            .setSize(new int(2), new int(3))
+            .setSize([] {return 2;}, [] {return 3;})
             .build();
     builder
             .newLinesIOSegment()
             .addVectorVariable(Vector::create(Y, "Y"))
-            .setSize(new int(3));
+            .setSize([] {return 3;});
     builder
             .newRawLinesIOSegment()
             .addVectorVariable(Vector::createRaw(V, "V"))
-            .setSize(new int(3));
+            .setSize([] {return 3;});
     builder
             .newLineIOSegment()
             .addScalarVariable(Scalar::create(X, "X"));
@@ -82,7 +82,7 @@ TEST_F(IOFormatBuilderTests, Building_Failed_LinesSegmentWithoutSizeNotLast) {
         builder
                 .newGridIOSegment()
                 .addMatrixVariable(Matrix::create(Z, "Z"))
-                .setSize(new int(2), new int(3));
+                .setSize([] {return 2;}, [] {return 3;});
         builder.build();
         FAIL();
     } catch (runtime_error& e) {
@@ -100,7 +100,7 @@ TEST_F(IOFormatBuilderTests, Building_Failed_LinesSegmentWithoutSizeNotLast) {
         builder
                 .newGridIOSegment()
                 .addMatrixVariable(Matrix::create(Z, "Z"))
-                .setSize(new int(2), new int(3));
+                .setSize([] {return 2;}, [] {return 3;});
         builder.build();
         FAIL();
     } catch (runtime_error& e) {
@@ -121,7 +121,7 @@ TEST_F(IOFormatBuilderTests, Building_Failed_RawLinesSegmentWithoutSizeNotLast) 
         builder
                 .newGridIOSegment()
                 .addMatrixVariable(Matrix::create(Z, "Z"))
-                .setSize(new int(2), new int(3));
+                .setSize([] {return 2;}, [] {return 3;});
         builder.build();
         FAIL();
     } catch (runtime_error& e) {
@@ -139,7 +139,7 @@ TEST_F(IOFormatBuilderTests, Building_Failed_RawLinesSegmentWithoutSizeNotLast) 
         builder
                 .newGridIOSegment()
                 .addMatrixVariable(Matrix::create(Z, "Z"))
-                .setSize(new int(2), new int(3));
+                .setSize([] {return 2;}, [] {return 3;});
         builder.build();
         FAIL();
     } catch (runtime_error& e) {

--- a/test/unit/tcframe/spec/io/LineIOSegmentBuilderTests.cpp
+++ b/test/unit/tcframe/spec/io/LineIOSegmentBuilderTests.cpp
@@ -20,13 +20,13 @@ protected:
 TEST_F(LineIOSegmentBuilderTests, Building_Successful) {
     LineIOSegment* segment = builder
             .addScalarVariable(Scalar::create(A, "A"))
-            .addVectorVariable(Vector::create(B, "B"), new int(7))
+            .addVectorVariable(Vector::create(B, "B"), [] {return 7;})
             .addVectorVariable(Vector::create(C, "C"))
             .build();
 
     EXPECT_THAT(segment->variables(), ElementsAre(
             LineIOSegmentVariable(Scalar::create(A, "A")),
-            LineIOSegmentVariable(Vector::create(B, "B"), new int(7)),
+            LineIOSegmentVariable(Vector::create(B, "B"), [] {return 7;}),
             LineIOSegmentVariable(Vector::create(C, "C"))));
 }
 
@@ -35,7 +35,7 @@ TEST_F(LineIOSegmentBuilderTests, Building_Failed_VectorWithoutSizeNotLast) {
         builder
                 .addScalarVariable(Scalar::create(A, "A"))
                 .addVectorVariable(Vector::create(B, "B"))
-                .addVectorVariable(Vector::create(C, "C"), new int(7))
+                .addVectorVariable(Vector::create(C, "C"), [] {return 7;})
                 .build();
         FAIL();
     } catch (runtime_error& e) {

--- a/test/unit/tcframe/spec/io/LinesIOSegmentBuilderTests.cpp
+++ b/test/unit/tcframe/spec/io/LinesIOSegmentBuilderTests.cpp
@@ -23,13 +23,13 @@ TEST_F(LinesIOSegmentBuilderTests, Building_Successful) {
     LinesIOSegment* segment = builder
             .addVectorVariable(Vector::create(X, "X"))
             .addVectorVariable(Vector::create(Y, "Y"))
-            .setSize(new int(3))
+            .setSize([] {return 3;})
             .build();
 
     ASSERT_THAT(segment->variables(), SizeIs(2));
     EXPECT_TRUE(segment->variables()[0]->equals(Vector::create(X, "X")));
     EXPECT_TRUE(segment->variables()[1]->equals(Vector::create(Y, "Y")));
-    EXPECT_THAT(*segment->size(), Eq(3));
+    EXPECT_THAT(segment->size()(), Eq(3));
 }
 
 TEST_F(LinesIOSegmentBuilderTests, Building_WithoutSize_Successful) {
@@ -48,20 +48,20 @@ TEST_F(LinesIOSegmentBuilderTests, Building_WithJaggedVector_Successful) {
             .addVectorVariable(Vector::create(X, "X"))
             .addVectorVariable(Vector::create(Y, "Y"))
             .addJaggedVectorVariable(Matrix::create(Z, "Z"))
-            .setSize(new int(4))
+            .setSize([] {return 4;})
             .build();
 
     ASSERT_THAT(segment->variables(), SizeIs(3));
     EXPECT_TRUE(segment->variables()[0]->equals(Vector::create(X, "X")));
     EXPECT_TRUE(segment->variables()[1]->equals(Vector::create(Y, "Y")));
     EXPECT_TRUE(segment->variables()[2]->equals(Matrix::create(Z, "Z")));
-    EXPECT_THAT(*segment->size(), Eq(4));
+    EXPECT_THAT(segment->size()(), Eq(4));
 }
 
 TEST_F(LinesIOSegmentBuilderTests, Building_Failed_NoVariables) {
     try {
         builder
-                .setSize(new int(4))
+                .setSize([] {return 4;})
                 .build();
         FAIL();
     } catch (runtime_error& e) {
@@ -75,7 +75,7 @@ TEST_F(LinesIOSegmentBuilderTests, Building_Failed_JaggedVectorNotLast) {
                 .addVectorVariable(Vector::create(Y, "Y"))
                 .addJaggedVectorVariable(Matrix::create(Z, "Z"))
                 .addVectorVariable(Vector::create(X, "X"))
-                .setSize(new int(5))
+                .setSize([] {return 5;})
                 .build();
         FAIL();
     } catch (runtime_error& e) {

--- a/test/unit/tcframe/spec/io/RawLinesIOSegmentBuilderTests.cpp
+++ b/test/unit/tcframe/spec/io/RawLinesIOSegmentBuilderTests.cpp
@@ -18,11 +18,11 @@ protected:
 TEST_F(RawLinesIOSegmentBuilderTests, Building_Successful) {
     RawLinesIOSegment* segment = builder
             .addVectorVariable(Vector::createRaw(V, "V"))
-            .setSize(new int(2))
+            .setSize([] {return 2;})
             .build();
 
     EXPECT_TRUE(segment->variable()->equals(Vector::createRaw(V, "V")));
-    EXPECT_THAT(*segment->size(), Eq(2));
+    EXPECT_THAT(segment->size()(), Eq(2));
 }
 
 TEST_F(RawLinesIOSegmentBuilderTests, Building_WithoutSize_Successful) {
@@ -36,7 +36,7 @@ TEST_F(RawLinesIOSegmentBuilderTests, Building_WithoutSize_Successful) {
 TEST_F(RawLinesIOSegmentBuilderTests, Building_Failed_NoVariables) {
     try {
         builder
-                .setSize(new int(2))
+                .setSize([] {return 2;})
                 .build();
         FAIL();
     } catch (runtime_error& e) {
@@ -49,7 +49,7 @@ TEST_F(RawLinesIOSegmentBuilderTests, Building_Failed_MultipleVariables) {
         builder
                 .addVectorVariable(Vector::createRaw(V, "V"))
                 .addVectorVariable(Vector::createRaw(V, "V"))
-                .setSize(new int(2))
+                .setSize([] {return 2;})
                 .build();
         FAIL();
     } catch (runtime_error& e) {


### PR DESCRIPTION
E.g. `SIZE(N - 1)`. Previously it would be considered as an rvalue and thus its
value is always taken eagerly, which is incorrect.